### PR TITLE
Clarifying license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='santiago.pivetta@gmail.com',
     url='https://github.com/paivett/requests-curl',
     description='This package allows using requests library with pycurl as backend.',
-    license='MIT',
+    license='Unlicense',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: The Unlicense (Unlicense)',
         'Operating System :: OS Independent',
         'Natural Language :: English',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi @paivett. I am looking to fork your adapter to add another protocol to requests. While I am going through files I've noticed the license inconsistency in `setup.py` after https://github.com/paivett/requests-curl/commit/e1b9e406c8bb7a1dcc9000698a74523f70fabd98 and decided to clarify it.